### PR TITLE
fix a typo in compoundVariants

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -250,7 +250,7 @@ export type GlobalStyles<AliasTypes, TokenTypes, Variants> = GlobalVariantSx<
     AliasTypes,
     TokenTypes
   >;
-  compundVariants?: readonly GlobalCompoundVariant<
+  compoundVariants?: readonly GlobalCompoundVariant<
     'variants' extends keyof Variants ? Variants['variants'] : unknown,
     AliasTypes,
     TokenTypes


### PR DESCRIPTION
**What**
GlobalStyles has a typo of compundVariants rather than compundVariants. This fixes the GlobalStyles type.